### PR TITLE
GH-3: remove /tmp permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,5 @@ RUN apt-get autoremove -y \
 
 RUN echo "export DISABLE_AUTO_TITLE=true" >> /root/.zshrc
 RUN echo "source /opt/ros/humble/setup.zsh" >> /root/.zshrc
-RUN chmod 0700 /tmp
 
 CMD [ "tmuxinator", "start", "-p", "/root/.session.yml" ]


### PR DESCRIPTION
Removed explicit /tmp permissions as they made it impossible to update system deps.

Fixes #3 